### PR TITLE
Add presentation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You defined `#old?` in your model because it's not a presentation concern. Good 
 
 `Frosting::BasePresenter` delegates to the resource you're presenting, and it also has access to the view context. It doesn't delegate anything by default, but you can delegate things like `link_to` and `content_tag` if it makes your life easier. You should probably make your own base presenter that inherits from frosting's base. It's your life, and you should do what you want to.
 
+You can also call `present_collection @posts` should you be dealing with a collection of posts and want them all to be presented.
+
 ## About Foraker Labs
 
 <img src="http://assets.foraker.com/foraker_logo.png" width="400" height="62">

--- a/lib/frosting/repository.rb
+++ b/lib/frosting/repository.rb
@@ -23,7 +23,7 @@ module Frosting
     private_class_method :infer_presenter
 
     def self.procify(arg)
-      arg.respond_to?(:call) ? arg : proc { arg }
+      arg.respond_to?(:call) ? arg : lambda { |_| arg }
     end
     private_class_method :procify
   end

--- a/lib/frosting/repository.rb
+++ b/lib/frosting/repository.rb
@@ -3,12 +3,14 @@ require "active_support/core_ext/module/delegation"
 
 module Frosting
   class Repository
+    class PresenterMissingError < StandardError; end
+
     def self.present(resource, options = {})
       klass = options.fetch(:presenter) { infer_presenter(resource) }
       klass = procify(klass).call(resource)
       klass.new(resource, options[:context])
-    rescue LoadError
-      raise "No such presenter: #{klass}"
+    rescue LoadError, NameError
+      raise PresenterMissingError.new("No such presenter: #{klass}")
     end
 
     def self.present_collection(collection, options = {})

--- a/lib/frosting/repository.rb
+++ b/lib/frosting/repository.rb
@@ -3,18 +3,10 @@ require "active_support/core_ext/module/delegation"
 
 module Frosting
   class Repository
-    def self.infer_presenter(resource)
-      "Presenters::#{resource.class.name}".constantize
-    end
-
-    def self.procify(arg)
-      arg.respond_to?(:call) ? arg : Proc.new { arg }
-    end
-
     def self.present(resource, options = {})
       klass = options.fetch(:presenter) { infer_presenter(resource) }
       klass = procify(klass).call(resource)
-      klass.new(resource, options.fetch(:context))
+      klass.new(resource, options[:context])
     rescue LoadError
       raise "No such presenter: #{klass}"
     end
@@ -22,6 +14,16 @@ module Frosting
     def self.present_collection(collection, options = {})
       PresentedCollection.new(collection, options)
     end
+
+    def self.infer_presenter(resource)
+      "Presenters::#{resource.class.name}".constantize
+    end
+    private_class_method :infer_presenter
+
+    def self.procify(arg)
+      arg.respond_to?(:call) ? arg : proc { arg }
+    end
+    private_class_method :procify
   end
 
   class PresentedCollection < SimpleDelegator

--- a/lib/frosting/repository.rb
+++ b/lib/frosting/repository.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/module/delegation"
 
 module Frosting
   class Repository
@@ -12,7 +13,26 @@ module Frosting
     end
 
     def self.present_collection(collection, options = {})
-      collection.map { |resource| present(resource, options) }
+      PresentedCollection.new(collection, options)
+    end
+  end
+
+  class PresentedCollection < SimpleDelegator
+    include Enumerable
+
+    delegate :each, to: :presented_collection
+
+    def initialize(collection, options)
+      @options = options
+      super(collection)
+    end
+
+    private
+
+    def presented_collection
+      __getobj__.map do |resource|
+        Repository.present(resource, @options)
+      end
     end
   end
 end

--- a/lib/frosting/version.rb
+++ b/lib/frosting/version.rb
@@ -1,3 +1,3 @@
 module Frosting
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/frosting/repository_spec.rb
+++ b/spec/frosting/repository_spec.rb
@@ -35,6 +35,19 @@ module Frosting
         its(:context)  { should eq context }
       end
 
+      context "specifying a presenter class via proc" do
+        subject do
+          described_class.present(resource, {
+            context:   context,
+            presenter: ->(resource) { Presenters::Test::Alternative }
+          })
+        end
+
+        it { should be_instance_of(Presenters::Test::Alternative) }
+        its(:resource) { should eq resource }
+        its(:context)  { should eq context }
+      end
+
       it "throws an exception when the resource has no presenter" do
         class Test::OtherResource ; end
         resource = Test::OtherResource.new

--- a/spec/frosting/repository_spec.rb
+++ b/spec/frosting/repository_spec.rb
@@ -69,7 +69,7 @@ module Frosting
       end
 
       before do
-        described_class.stub(:present)
+        allow(described_class).to receive(:present)
           .with(resource, {option: :val})
           .and_return(presented_resource)
       end

--- a/spec/frosting/repository_spec.rb
+++ b/spec/frosting/repository_spec.rb
@@ -51,7 +51,9 @@ module Frosting
       it "throws an exception when the resource has no presenter" do
         class Test::OtherResource ; end
         resource = Test::OtherResource.new
-        expect { described_class.present(resource, context: context) }.to raise_error(NameError)
+        expect {
+          described_class.present(resource, context: context)
+        }.to raise_error(Frosting::Repository::PresenterMissingError)
       end
     end
 

--- a/spec/frosting/repository_spec.rb
+++ b/spec/frosting/repository_spec.rb
@@ -43,11 +43,30 @@ module Frosting
     end
 
     describe ".present_collection" do
-      it "presents each item in the collection with options" do
-        resource = double
-        described_class.should_receive(:present)
+      class Collection < Array
+        def test_method
+          "cats"
+        end
+      end
+
+      let(:resource) { double }
+      let(:presented_resource) { double }
+      let(:presented_collection) do
+        described_class.present_collection(Collection.new.push(resource), {option: :val})
+      end
+
+      before do
+        described_class.stub(:present)
           .with(resource, {option: :val})
-        described_class.present_collection([resource], {option: :val})
+          .and_return(presented_resource)
+      end
+
+      it "presents each item in the collection with options" do
+        expect(presented_collection.each.to_a).to eq [presented_resource]
+      end
+
+      it "still acts like the original collection" do
+        expect(presented_collection.test_method).to eq "cats"
       end
     end
   end


### PR DESCRIPTION
Adds ability to delegate methods to the wrapped collection e.g. you present a paginated active record relation it will still respond to the appropriate methods. 

Adds ability to specify a presenter as a proc to make it easier to present collections which include a variety of objects.