### PR TITLE
Fix presented collection addition

### DIFF
--- a/frosting.gemspec
+++ b/frosting.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'frosting'
-  s.version     = '0.0.6'
-  s.date        = '2014-02-04'
+  s.version     = '0.0.7'
+  s.date        = '2016-01-26'
   s.summary     = "Let's make presenters easy."
   s.description = "Adds some methods to your controllers and a base presenter. Get that presentation logic out of your models."
   s.authors     = ["Ben Eddy", "Jon Evans"]

--- a/lib/frosting/repository.rb
+++ b/lib/frosting/repository.rb
@@ -31,11 +31,15 @@ module Frosting
   class PresentedCollection < SimpleDelegator
     include Enumerable
 
-    delegate :each, to: :presented_collection
+    delegate :each, :to_a, to: :presented_collection
 
     def initialize(collection, options)
       @options = options
       super(collection)
+    end
+
+    def +(other)
+      to_a + other.to_a
     end
 
     private

--- a/lib/frosting/version.rb
+++ b/lib/frosting/version.rb
@@ -1,3 +1,3 @@
 module Frosting
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end

--- a/spec/frosting/repository_spec.rb
+++ b/spec/frosting/repository_spec.rb
@@ -77,11 +77,16 @@ module Frosting
       end
 
       it "presents each item in the collection with options" do
-        expect(presented_collection.each.to_a).to eq [presented_resource]
+        expect(presented_collection.to_a).to eq [presented_resource]
       end
 
       it "still acts like the original collection" do
         expect(presented_collection.test_method).to eq "cats"
+      end
+
+      it "allows addition of presented collections" do
+        expect((presented_collection + presented_collection).to_a).
+          to eq [presented_resource, presented_resource]
       end
     end
   end


### PR DESCRIPTION
Otherwise, if you add an instance of a presented instance with another (or anything really), it delegates `+` to the collection you're presenting, and you don't end up with presented objects.